### PR TITLE
fix(gjs): add workarounds for AstalNiri

### DIFF
--- a/lang/gjs/src/overrides.ts
+++ b/lang/gjs/src/overrides.ts
@@ -83,3 +83,9 @@ await suppress(import("gi://AstalWp"), ({ Wp, Audio, Video }) => {
     patch(Video.prototype, "sources")
     patch(Video.prototype, "devices")
 })
+
+await suppress(import("gi://AstalNiri"), ({ Niri }) => {
+    patch(Niri.prototype, "workspaces")
+    patch(Niri.prototype, "windows")
+    patch(Niri.prototype, "outputs")
+})


### PR DESCRIPTION
Fix this [Error](https://aylur.github.io/astal/guide/typescript/faq#error-can-t-convert-non-null-pointer-to-js-value) by adding a [workaround](https://github.com/Aylur/astal/blob/main/lang/gjs/src/overrides.ts)