### PR TITLE
fix(gjs): add workarounds for AstalNiri

### DIFF
--- a/lang/gjs/src/overrides.ts
+++ b/lang/gjs/src/overrides.ts
@@ -60,6 +60,12 @@ await suppress(import("gi://AstalNetwork"), ({ Wifi }) => {
     patch(Wifi.prototype, "accessPoints")
 })
 
+await suppress(import("gi://AstalNiri"), ({ Niri }) => {
+    patch(Niri.prototype, "workspaces")
+    patch(Niri.prototype, "windows")
+    patch(Niri.prototype, "outputs")
+})
+
 await suppress(import("gi://AstalNotifd"), ({ Notifd, Notification }) => {
     patch(Notifd.prototype, "notifications")
     patch(Notification.prototype, "actions")


### PR DESCRIPTION
Fix this [Error](https://aylur.github.io/astal/guide/typescript/faq#error-can-t-convert-non-null-pointer-to-js-value) by adding a [workaround](https://github.com/Aylur/astal/blob/main/lang/gjs/src/overrides.ts)