### PR TITLE
fix(niri): notify when windows or workspaces change

### DIFF
--- a/lib/niri/niri.vala
+++ b/lib/niri/niri.vala
@@ -195,6 +195,7 @@ public class Niri : Object {
             }
         }
         workspaces_changed(workspaces);
+        notify_property("workspaces");
     }
 
     private void on_workspace_activated(Json.Object event) {
@@ -252,6 +253,7 @@ public class Niri : Object {
             if (window.is_focused) focused_window_id = window.id;
         }
         windows_changed(windows);
+        notify_property("windows");
     }
 
     private void on_window_opened_or_changed(Json.Object event) {
@@ -267,6 +269,7 @@ public class Niri : Object {
             window = new Window.from_json(window_object);
             _windows.insert(window_id, window);
             window_opened(window);
+            notify_property("windows");
         }
 
         if (window.is_focused) {
@@ -286,6 +289,7 @@ public class Niri : Object {
 
         window_closed(id);
         window.closed();
+        notify_property("windows");
     }
 
     private void on_window_focus_changed(Json.Object event) {


### PR DESCRIPTION
Hi!

So, since the `workspaces` property started working in gjs, i tried to bind to it so i could set the workspaces on the bar...
Well that didn't work because it didn't get updated. 

I checked the [vala docs](https://docs.vala.dev/tutorials/programming-language/main/03-00-object-oriented-programming/03-05-properties.html) and read this about the `notify` signal:

>  This signal gets emitted every time a property of its object changes

And since `workspaces` and `windows` are `HashTables`, the properties don't change.

So this fix allows to notify that the properties change :)
I tested it with this [config](https://github.com/viceav/dotfiles/blob/master/ags/widget/bar/button/Niri.tsx)