### PR TITLE
Fix some inconsistencies

### DIFF
--- a/lib/niri/niri.vala
+++ b/lib/niri/niri.vala
@@ -250,10 +250,7 @@ public class Niri : Object {
         foreach (var element in windows_arr.get_elements()) {
             var window = new Window.from_json(element.get_object());
             _windows.insert(window.id, window);
-            if (window.is_focused) {
-                focused_window_id = window.id;
-                focused_window = window;
-            }
+            if (window.is_focused) update_focused_window(window.id);
         }
         windows_changed(windows);
         notify_property("windows");
@@ -359,6 +356,9 @@ public class Niri : Object {
         if (new_focused != null) {
             new_focused.is_focused = true;
             focused_window = new_focused;
+            if (new_focused.id == id) {
+                notify_property("focused_window");
+            }
         } else {
           focused_window = null;
         }

--- a/lib/niri/niri.vala
+++ b/lib/niri/niri.vala
@@ -358,8 +358,12 @@ public class Niri : Object {
 
         focused_window_id = id;
         var new_focused = _windows.get(focused_window_id);
-        new_focused.is_focused = true;
-        focused_window = new_focused;
+        if (new_focused != null) {
+            new_focused.is_focused = true;
+            focused_window = new_focused;
+        } else {
+          focused_window = null;
+        }
 
         window_focus_changed(focused_window_id);
     }

--- a/lib/niri/niri.vala
+++ b/lib/niri/niri.vala
@@ -250,7 +250,10 @@ public class Niri : Object {
         foreach (var element in windows_arr.get_elements()) {
             var window = new Window.from_json(element.get_object());
             _windows.insert(window.id, window);
-            if (window.is_focused) focused_window_id = window.id;
+            if (window.is_focused) {
+                focused_window_id = window.id;
+                focused_window = window;
+            }
         }
         windows_changed(windows);
         notify_property("windows");
@@ -346,11 +349,6 @@ public class Niri : Object {
     private void update_focused_window(int64? _id) {
         int64 id = -1;
         if(_id != null) id = _id;
-        if (focused_window_id == -1) {
-            focused_window_id = id;
-            window_focus_changed(focused_window_id);
-            return;
-        }
 
         // remove focused state from previous window
         var prev = _windows.get(focused_window_id);


### PR DESCRIPTION
- For the `on_windows_changed` function ensure `focused_window` gets updated
- For the `update_focused_window` handle when the `new_focused` window is null

Also, in the `update_focused_window` i remove this block of code
```vala
if (focused_window_id == -1) {
    focused_window_id = id;
    window_focus_changed(focused_window_id);
    return;
}
```

The main reason was because even if there wasn't a previous `focused_window`, it's still necessary to update the `focused_window` property and tell the `new_focused` that is focused (if there is a `new_focused`)

So it was between copying that whole block of code so it would get executed inside the if,  or just remove the if statement
