### PR TITLE
refactor: remove objects ids from properties

### DIFF
--- a/lib/niri/niri.vala
+++ b/lib/niri/niri.vala
@@ -349,16 +349,19 @@ public class Niri : Object {
 
         // remove focused state from previous window
         var prev = _windows.get(focused_window_id);
-        if (prev != null) prev.is_focused = focused_window_id == id;
+        if (prev != null) {
+            prev.is_focused = focused_window_id == id;
+            if (prev.id == id) {
+                notify_property("focused_window");
+                return;
+            }
+        }
 
         focused_window_id = id;
         var new_focused = _windows.get(focused_window_id);
         if (new_focused != null) {
             new_focused.is_focused = true;
             focused_window = new_focused;
-            if (new_focused.id == id) {
-                notify_property("focused_window");
-            }
         } else {
           focused_window = null;
         }


### PR DESCRIPTION
Since `Window` and `Workspace`  already have the `id` property, it isn't necessary to have the objects ids as properties.
We can just ask for the `id` of the focused `Window` or `Workspace`

With this approach we don't need to worry about handling `ids` property too, meaning less code now and possible in the future.