### PR TITLE
refactor event handling

### DIFF
--- a/lib/niri/cli.vala
+++ b/lib/niri/cli.vala
@@ -33,8 +33,8 @@ int main(string[] argv) {
         return 0;
     }
 
-    AstalNiri.get_default().event.connect((event) => {
-        print("%s\n", Json.to_string(event, false));
+    AstalNiri.get_default().event_stream.connect((_, payload) => {
+        print("%s\n", payload );
     });
 
     new MainLoop(null, false).run();

--- a/lib/niri/niri.vala
+++ b/lib/niri/niri.vala
@@ -3,10 +3,7 @@ public Niri get_default() {
     return Niri.get_default();
 }
 public class Niri : Object {
-    [CCode(has_target = false)]
-    private delegate void EventHandler(Niri self, Json.Object object);
-    private static HashTable<string, EventHandler> event_handlers =
-        new HashTable<string, EventHandler>(str_hash, str_equal);
+
 
     internal HashTable<uint64?, Workspace>  _workspaces =
         new HashTable<uint64?,  Workspace> (int64_hash, int64_equal);
@@ -68,21 +65,6 @@ public class Niri : Object {
     static Niri _instance;
 
     // https://yalter.github.io/niri/niri_ipc/enum.Event.html
-    static construct {
-        event_handlers.insert("WorkspacesChanged",            (EventHandler) on_workspaces_changed);
-        event_handlers.insert("WorkspaceActivated",           (EventHandler) on_workspace_activated);
-        event_handlers.insert("WorkspaceActiveWindowChanged", (EventHandler) on_workspace_active_window_changed);
-        event_handlers.insert("WindowsChanged",               (EventHandler) on_windows_changed);
-        event_handlers.insert("WindowOpenedOrChanged",        (EventHandler) on_window_opened_or_changed);
-        event_handlers.insert("WindowClosed",                 (EventHandler) on_window_closed);
-        event_handlers.insert("WindowFocusChanged",           (EventHandler) on_window_focus_changed);
-        event_handlers.insert("WindowUrgencyChanged",         (EventHandler) on_window_urgency_changed);
-        event_handlers.insert("WorkspaceUrgencyChanged",      (EventHandler) on_workspace_urgency_changed);
-        event_handlers.insert("KeyboardLayoutsChanged",       (EventHandler) on_keyboard_layouts_changed);
-        event_handlers.insert("KeyboardLayoutSwitched",       (EventHandler) on_keyboard_layout_switched);
-        event_handlers.insert("OverviewOpenedOrClosed",       (EventHandler) on_overview_opened_or_closed);
-
-    }
 
     public static Niri? get_default() {
         if (_instance != null)
@@ -137,13 +119,45 @@ public class Niri : Object {
 
                 var event_type = obj.get_members().data;
                 var event = obj.get_object_member(event_type);
-                var handler = event_handlers.get(event_type);
-                if (handler == null) {
-                    warning("Unhandled event %s", event_type);
-                    continue;
-                }
 
-                handler(this, event);
+                switch (event_type) {
+                    case "WorkspacesChanged":
+                        on_workspaces_changed(event);
+                        break;
+                    case "WorkspaceActivated":
+                        on_workspace_activated(event);
+                        break;
+                    case "WorkspaceActiveWindowChanged":
+                        on_workspace_active_window_changed(event);
+                        break;
+                    case "WindowsChanged":
+                        on_windows_changed(event);
+                        break;
+                    case "WindowOpenedOrChanged":
+                        on_window_opened_or_changed(event);
+                        break;
+                    case "WindowClosed":
+                        on_window_closed(event);
+                        break;
+                    case "WindowFocusChanged":
+                        on_window_focus_changed(event);
+                        break;
+                    case "WindowUrgencyChanged":
+                        on_window_urgency_changed(event);
+                        break;
+                    case "WorkspaceUrgencyChanged":
+                        on_workspace_urgency_changed(event);
+                        break;
+                    case "KeyboardLayoutsChanged":
+                        on_keyboard_layouts_changed(event);
+                        break;
+                    case "KeyboardLayoutSwitched":
+                        on_keyboard_layout_switched(event);
+                        break;
+                    case "OverviewOpenedOrClosed":
+                        on_overview_opened_or_closed(event);
+                        break;
+                }
             }
         } catch (Error err) {
             critical("%s", err.message);

--- a/lib/niri/niri.vala
+++ b/lib/niri/niri.vala
@@ -4,7 +4,6 @@ public Niri get_default() {
 }
 public class Niri : Object {
 
-
     internal HashTable<uint64?, Workspace>  _workspaces =
         new HashTable<uint64?,  Workspace> (int64_hash, int64_equal);
     internal HashTable<uint64?, Window>     _windows =
@@ -35,7 +34,7 @@ public class Niri : Object {
     } }
 
     /** An event has been received. */
-    public signal void event(Json.Node event);
+    public signal void event_stream(string event, string payload);
     /** The list of workspaces changed. */
     public signal void workspaces_changed(List<weak Workspace> workspaces);
     public signal void workspace_activated(uint64 workspace, bool focused);
@@ -61,9 +60,8 @@ public class Niri : Object {
     public signal void keyboard_layouts_changed(Array<string> keyboard_layouts);
     public signal void keyboard_layout_switched(uint8 idx);
 
-    private IPC? event_socket;
+    private IPC? stream_socket;
     static Niri _instance;
-
 
     public static Niri? get_default() {
         if (_instance != null)
@@ -72,9 +70,9 @@ public class Niri : Object {
         var instance = new Niri();
         instance.keyboard_layouts = new Array<string>();
         instance.overview = new Overview();
-        instance.event_socket = IPC.connect();
-
-        instance.watch_events.begin();
+        instance.stream_socket = IPC.connect();
+        instance.stream_socket.event_stream.connect(instance.handle_events);
+        instance.stream_socket.stream.begin();
 
         _instance = instance;
         return _instance;
@@ -96,187 +94,160 @@ public class Niri : Object {
         return (int) (a.idx > b.idx) - (int) (a.idx < b.idx);
     }
 
-    private async void watch_events() {
-        try {
-            var istream = event_socket.send_str("\"EventStream\"\n");
-            var line = yield istream.read_line_async();
-            if (line != "{\"Ok\":\"Handled\"}") {
-                critical("Event Stream Error: %s", line);
-                return;
-            }
-            line = null;
+    // https://yalter.github.io/niri/niri_ipc/enum.Event.html
+    private async void handle_events(string event_type, Json.Node node) {
+        event_stream(event_type, Json.to_string(node, false));
+        var payload = node.get_object().get_object_member(event_type);
+        switch (event_type) {
+            case "WorkspacesChanged":
+                var workspaces_arr = payload.get_array_member("workspaces");
 
-            while (true) {
-                var ev = Json.from_string(yield istream.read_line_async());
-                event.emit(ev);
+                _workspaces.remove_all();
+                update_outputs.begin();
+                foreach (var element in workspaces_arr.get_elements()) {
+                    var workspace = new Workspace.from_json(element.get_object());
+                    _workspaces.insert(workspace.id, workspace);
+                    if(workspace.is_focused) {
+                        update_focused_workspace(workspace.id);
+                    }
+                }
+                workspaces_changed(workspaces);
+                notify_property("workspaces");
+                break;
+            case "WorkspaceActivated":
+                var id = payload.get_int_member("id");
+                var focused = payload.get_boolean_member("focused");
 
-                var obj = ev.get_object();
-                if (obj == null || obj.get_size() != 1U) {
-                    critical("Invalid event '%s'", Json.to_string(ev, false));
-                    continue;
+                var activated_workspace = get_workspace(id);
+                if (activated_workspace == null) {
+                    unknown_workspace(id);
+                    return;
                 }
 
-                var event_type = obj.get_members().data;
-                var event = obj.get_object_member(event_type);
-
-                // https://yalter.github.io/niri/niri_ipc/enum.Event.html
-                switch (event_type) {
-                    case "WorkspacesChanged":
-                        var workspaces_arr = event.get_array_member("workspaces");
-
-                        _workspaces.remove_all();
-                        update_outputs.begin();
-                        foreach (var element in workspaces_arr.get_elements()) {
-                            var workspace = new Workspace.from_json(element.get_object());
-                            _workspaces.insert(workspace.id, workspace);
-                            if(workspace.is_focused) {
-                                update_focused_workspace(workspace.id);
-                            }
-                        }
-                        workspaces_changed(workspaces);
-                        notify_property("workspaces");
-                        break;
-                    case "WorkspaceActivated":
-                        var id = event.get_int_member("id");
-                        var focused = event.get_boolean_member("focused");
-
-                        var activated_workspace = get_workspace(id);
-                        if (activated_workspace == null) {
-                            unknown_workspace(id);
-                            return;
-                        }
-
-                        foreach (var workspace in _workspaces.get_values()) {
-                            if (workspace.output == activated_workspace.output) {
-                              workspace.is_active = workspace == activated_workspace;
-                            }
-                        }
-                        if (focused) update_focused_workspace(id);
-
-                        workspace_activated(id, focused);
-                        activated_workspace.activated();
-                        break;
-                    case "WorkspaceActiveWindowChanged":
-                        var workspace_id = event.get_int_member("workspace_id");
-                        var _active_window_id = event.get_member("active_window_id");
-
-                        var workspace = get_workspace(workspace_id);
-                        if (workspace == null) {
-                            unknown_workspace(workspace_id);
-                            return;
-                        }
-
-                        if (_active_window_id.is_null()) {
-                            workspace.active_window_id = 0;
-                            workspace_active_window_changed(workspace_id, 0);
-                        } else {
-                            var active_window_id = _active_window_id.get_int();
-                            workspace.active_window_id = active_window_id;
-                            workspace_active_window_changed(workspace_id, active_window_id);
-                        }
-                        workspace.active_window_changed(workspace.active_window_id);
-                        break;
-                    case "WindowsChanged":
-                        var windows_arr = event.get_array_member("windows");
-
-                        _windows.remove_all();
-                        foreach (var element in windows_arr.get_elements()) {
-                            var window = new Window.from_json(element.get_object());
-                            _windows.insert(window.id, window);
-                            if (window.is_focused) update_focused_window(window.id);
-                        }
-                        windows_changed(windows);
-                        notify_property("windows");
-                        break;
-                    case "WindowOpenedOrChanged":
-                        var window_object = event.get_object_member("window");
-                        var window_id = window_object.get_int_member("id");
-
-                        var window = _windows.get(window_id);
-                        if (window != null) {
-                            window.sync(window_object);
-                            window_changed(window);
-                        } else {
-                            window = new Window.from_json(window_object);
-                            _windows.insert(window_id, window);
-                            window_opened(window);
-                            notify_property("windows");
-                            get_workspace(window.workspace_id)?.notify_property("windows");
-                        }
-
-                        if (window.is_focused) update_focused_window(window.id);
-                        window_opened_or_changed(window);
-                        break;
-                    case "WindowClosed":
-                        var id = event.get_int_member("id");
-
-                        var window = _windows.take(id);
-                        if (window == null) {
-                            unknown_window(id);
-                            return;
-                        }
-
-                        window_closed(id);
-                        window.closed();
-                        notify_property("windows");
-                        var workspace = get_workspace(window.workspace_id);
-                        if (workspace != null) workspace.notify_property("windows");
-                        break;
-                    case "WindowFocusChanged":
-                        var _id = event.get_member("id");
-                        uint64 id = 0;
-                        if (!_id.is_null())  id = _id.get_int();
-
-                        update_focused_window(id);
-                        break;
-                    case "WindowUrgencyChanged":
-                        var id = event.get_int_member("id");
-                        var urgent = event.get_boolean_member("urgent");
-
-                        var window = get_window(id);
-                        if(window != null) {
-                            window.is_urgent = urgent;
-                        }
-
-                        window_urgency_changed(id, urgent);
-                        break;
-                    case "WorkspaceUrgencyChanged":
-                        var id = event.get_int_member("id");
-                        var urgent = event.get_boolean_member("urgent");
-
-                        var workspace = get_workspace(id);
-                        if(workspace != null) {
-                            workspace.is_urgent = urgent;
-                        }
-                        workspace_urgency_changed(id, urgent);
-                        break;
-                    case "KeyboardLayoutsChanged":
-                        var layouts = event.get_object_member("keyboard_layouts");
-                        var names = layouts.get_array_member("names");
-
-                        foreach (var element in names.get_elements()) {
-                            keyboard_layouts.append_val(element.get_string());
-                        }
-
-                        keyboard_layout_idx = (uint8) layouts.get_int_member("current_idx");
-                        keyboard_layouts_changed(keyboard_layouts);
-                        break;
-                    case "KeyboardLayoutSwitched":
-                        keyboard_layout_idx = (uint8) event.get_int_member("idx");
-                        keyboard_layout_switched(keyboard_layout_idx);
-                        break;
-                    case "OverviewOpenedOrClosed":
-                        var is_open = event.get_boolean_member("is_open");
-                        overview.is_open = is_open;
-                        overview_opened_or_closed(is_open);
-                        break;
+                foreach (var workspace in _workspaces.get_values()) {
+                    if (workspace.output == activated_workspace.output) {
+                      workspace.is_active = workspace == activated_workspace;
+                    }
                 }
-            }
-        } catch (Error err) {
-            critical("%s", err.message);
-            return;
-        } finally {
-            event_socket.close();
+                if (focused) update_focused_workspace(id);
+
+                workspace_activated(id, focused);
+                activated_workspace.activated();
+                break;
+            case "WorkspaceActiveWindowChanged":
+                var workspace_id = payload.get_int_member("workspace_id");
+                var _active_window_id = payload.get_member("active_window_id");
+
+                var workspace = get_workspace(workspace_id);
+                if (workspace == null) {
+                    unknown_workspace(workspace_id);
+                    return;
+                }
+
+                if (_active_window_id.is_null()) {
+                    workspace.active_window_id = 0;
+                    workspace_active_window_changed(workspace_id, 0);
+                } else {
+                    var active_window_id = _active_window_id.get_int();
+                    workspace.active_window_id = active_window_id;
+                    workspace_active_window_changed(workspace_id, active_window_id);
+                }
+                workspace.active_window_changed(workspace.active_window_id);
+                break;
+            case "WindowsChanged":
+                var windows_arr = payload.get_array_member("windows");
+
+                _windows.remove_all();
+                foreach (var element in windows_arr.get_elements()) {
+                    var window = new Window.from_json(element.get_object());
+                    _windows.insert(window.id, window);
+                    if (window.is_focused) update_focused_window(window.id);
+                }
+                windows_changed(windows);
+                notify_property("windows");
+                break;
+            case "WindowOpenedOrChanged":
+                var window_object = payload.get_object_member("window");
+                var window_id = window_object.get_int_member("id");
+
+                var window = _windows.get(window_id);
+                if (window != null) {
+                    window.sync(window_object);
+                    window_changed(window);
+                } else {
+                    window = new Window.from_json(window_object);
+                    _windows.insert(window_id, window);
+                    window_opened(window);
+                    notify_property("windows");
+                    get_workspace(window.workspace_id)?.notify_property("windows");
+                }
+
+                if (window.is_focused) update_focused_window(window.id);
+                window_opened_or_changed(window);
+                break;
+            case "WindowClosed":
+                var id = payload.get_int_member("id");
+
+                var window = _windows.take(id);
+                if (window == null) {
+                    unknown_window(id);
+                    return;
+                }
+
+                window_closed(id);
+                window.closed();
+                notify_property("windows");
+                var workspace = get_workspace(window.workspace_id);
+                if (workspace != null) workspace.notify_property("windows");
+                break;
+            case "WindowFocusChanged":
+                var _id = payload.get_member("id");
+                uint64 id = 0;
+                if (!_id.is_null())  id = _id.get_int();
+
+                update_focused_window(id);
+                break;
+            case "WindowUrgencyChanged":
+                var id = payload.get_int_member("id");
+                var urgent = payload.get_boolean_member("urgent");
+
+                var window = get_window(id);
+                if(window != null) {
+                    window.is_urgent = urgent;
+                }
+
+                window_urgency_changed(id, urgent);
+                break;
+            case "WorkspaceUrgencyChanged":
+                var id = payload.get_int_member("id");
+                var urgent = payload.get_boolean_member("urgent");
+
+                var workspace = get_workspace(id);
+                if(workspace != null) {
+                    workspace.is_urgent = urgent;
+                }
+                workspace_urgency_changed(id, urgent);
+                break;
+            case "KeyboardLayoutsChanged":
+                var layouts = payload.get_object_member("keyboard_layouts");
+                var names = layouts.get_array_member("names");
+
+                foreach (var element in names.get_elements()) {
+                    keyboard_layouts.append_val(element.get_string());
+                }
+
+                keyboard_layout_idx = (uint8) layouts.get_int_member("current_idx");
+                keyboard_layouts_changed(keyboard_layouts);
+                break;
+            case "KeyboardLayoutSwitched":
+                keyboard_layout_idx = (uint8) payload.get_int_member("idx");
+                keyboard_layout_switched(keyboard_layout_idx);
+                break;
+            case "OverviewOpenedOrClosed":
+                var is_open = payload.get_boolean_member("is_open");
+                overview.is_open = is_open;
+                overview_opened_or_closed(is_open);
+                break;
         }
     }
 


### PR DESCRIPTION
Adds changes to event handling and signals based on comments from #24

> - Don't use a hashtable for event handlers, a simple switch case is a lot more readable.
> 
> - You don't have to warn on unknown events, just simply ignore in the default switch case. If a future version of Niri has a new event, users can handle it using the event signal until we push an update.
>
>-  Have the IPC class emit the events in the form of public signal void event(string event, Json.Node payload) which the Niri class handles in a switch case.
> 
>    - I'm not sure if it would be convenient or not, but we could also define each event payload as a Vala class and rely on `[Json.gobject_deserialize](https://valadoc.org/json-glib-1.0/Json.gobject_deserialize.html)
> 
> - Don't expose the event signal with a Json object as a parameter. The event signal of the Niri class should look like void event(string event, string payload), so that users can handle json as they like, for example in python and js using the json module.