### PR TITLE
feat(niri): add screencast objects

### DIFF
--- a/lib/niri/cast.vala
+++ b/lib/niri/cast.vala
@@ -1,0 +1,91 @@
+
+namespace AstalNiri {
+
+public class Cast : Object {
+    public signal void stopped();
+
+    // Stream ID of the screencast that uniquely identifies it.
+    public uint64 stream_id { get; private set; }
+    // Session ID of the screencast.
+    public uint64 session_id { get; private set; }
+    // Process ID of the screencast consumer, if known.
+    public int? pid { get; private set; }
+    // PipeWire node ID of the screencast stream.
+    public int? pw_node_id { get; private set; }
+
+    // Kind of this screencast. Pipewire | WlrScreencopy
+    public CastKind kind { get; private set; }
+
+    public bool is_active { get; internal set; }
+    public bool is_dynamic_target { get; private set; }
+
+    private string? active_output_name;
+    private int64? active_window_id;
+
+    // Replaces CastTarget
+    public unowned Window? window { get {
+        return Niri.get_default().get_window(active_window_id);
+    }}
+
+    public unowned Output? output { get {
+        return Niri.get_default().get_output(active_output_name);
+    }}
+
+    internal Cast.from_json(Json.Object object) {
+        sync(object);
+    }
+
+    internal void sync(Json.Object object) {
+        stream_id = (uint64) object.get_int_member("stream_id");
+        session_id = (uint64) object.get_int_member("session_id");
+        is_active = object.get_boolean_member("is_active");
+        is_dynamic_target = object.get_boolean_member("is_dynamic_target");
+
+        if (object.has_member("pid") && !object.get_null_member("pid")) {
+            pid = (int32) object.get_int_member("pid");
+        } else {
+            pid = null;
+        }
+
+        if (object.has_member("pw_node_id") && !object.get_null_member("pw_node_id")) {
+            pw_node_id = (int32) object.get_int_member("pw_node_id");
+        } else {
+            pw_node_id = null;
+        }
+
+        var k = object.get_string_member("kind");
+
+        if (k == "PipeWire") {
+            kind = CastKind.PipeWire;
+        } else if (k == "WlrScreencopy") {
+            kind = CastKind.WlrScreencopy;
+        } else {
+            warning("Unknown CastKind");
+        }
+
+        var target = object.get_object_member("target");
+
+        if (target.has_member("Nothing")) {
+            active_output_name = null;
+            active_window_id = null;
+        } else if (target.has_member("Output")) {
+            active_window_id = null;
+
+            active_output_name = target
+                .get_object_member("Output")
+                .get_string_member("name");
+
+        } else if (target.has_member("Window")) {
+            active_output_name = null;
+
+            active_window_id = target.get_object_member("Window")
+                  .get_int_member("id");
+        }
+
+    }
+
+    public bool stop() {
+        return msg.stop_cast((int)stream_id);
+    }
+}
+}

--- a/lib/niri/cast.vala
+++ b/lib/niri/cast.vala
@@ -8,27 +8,29 @@ public class Cast : Object {
     public uint64 stream_id { get; private set; }
     // Session ID of the screencast.
     public uint64 session_id { get; private set; }
-    // Process ID of the screencast consumer, if known.
-    public int? pid { get; private set; }
-    // PipeWire node ID of the screencast stream.
-    public int? pw_node_id { get; private set; }
-
     // Kind of this screencast. Pipewire | WlrScreencopy
     public CastKind kind { get; private set; }
-
-    public bool is_active { get; internal set; }
+    // Target being captured. None | Window | Output
+    public CastTarget target { get; private set; }
+    // Whether this is a Dynamic Cast Target screencast.
     public bool is_dynamic_target { get; private set; }
+    // Whether the cast is currently streaming frames.
+    public bool is_active { get; internal set; }
+    // Process ID of the screencast consumer, if known.
+    public int32? pid { get; private set; }
+    // PipeWire node ID of the screencast stream.
+    public uint32? pw_node_id { get; private set; }
 
-    private string? active_output_name;
-    private int64? active_window_id;
+    private string? target_output_name;
+    private uint64? target_window_id;
 
     // Replaces CastTarget
     public unowned Window? window { get {
-        return Niri.get_default().get_window(active_window_id);
+        return Niri.get_default().get_window(target_window_id);
     }}
 
     public unowned Output? output { get {
-        return Niri.get_default().get_output(active_output_name);
+        return Niri.get_default().get_output(target_output_name);
     }}
 
     internal Cast.from_json(Json.Object object) {
@@ -48,7 +50,7 @@ public class Cast : Object {
         }
 
         if (object.has_member("pw_node_id") && !object.get_null_member("pw_node_id")) {
-            pw_node_id = (int32) object.get_int_member("pw_node_id");
+            pw_node_id = (uint32) object.get_int_member("pw_node_id");
         } else {
             pw_node_id = null;
         }
@@ -63,22 +65,24 @@ public class Cast : Object {
             warning("Unknown CastKind");
         }
 
-        var target = object.get_object_member("target");
+        var t = object.get_object_member("target");
 
-        if (target.has_member("Nothing")) {
-            active_output_name = null;
-            active_window_id = null;
-        } else if (target.has_member("Output")) {
-            active_window_id = null;
+        if (t.has_member("Nothing")) {
+            target = CastTarget.None;
+            target_output_name = null;
+            target_window_id = null;
+        } else if (t.has_member("Output")) {
+            target = CastTarget.Output;
+            target_window_id = null;
 
-            active_output_name = target
-                .get_object_member("Output")
+            target_output_name = t.get_object_member("Output")
                 .get_string_member("name");
 
-        } else if (target.has_member("Window")) {
-            active_output_name = null;
+        } else if (t.has_member("Window")) {
+            target = CastTarget.Window;
+            target_output_name = null;
 
-            active_window_id = target.get_object_member("Window")
+            target_window_id = t.get_object_member("Window")
                   .get_int_member("id");
         }
 

--- a/lib/niri/meson.build
+++ b/lib/niri/meson.build
@@ -48,6 +48,7 @@ sources = [
   'output.vala',
   'structs.vala',
   'overview.vala',
+  'cast.vala',
   'msg.vala',
 ]
 

--- a/lib/niri/msg.vala
+++ b/lib/niri/msg.vala
@@ -739,6 +739,10 @@ public class msg : Object {
       return send_act("SetDynamicCastMonitor", serialize_fields({ str_member("output", output) }));
     }
 
+    public static bool stop_cast(int? id) {
+      return send_act("StopCast", serialize_fields({ int_member("session_id", id) }));
+    }
+
     public static bool set_window_height_adjust_fixed(int? id, int fixed_value) {
       return send_act("SetWindowHeight", serialize_fields({ int_member("id", id), obj_member("change", { int_member("AdjustFixed", fixed_value) }) }));
     }

--- a/lib/niri/niri.vala
+++ b/lib/niri/niri.vala
@@ -10,6 +10,9 @@ public class Niri : Object {
         new HashTable<uint64?,  Window>    (int64_hash, int64_equal);
     internal HashTable<string?, Output>     _outputs =
         new HashTable<string?,  Output>    (str_hash, str_equal);
+    internal HashTable<uint64?, Cast>  _casts =
+        new HashTable<uint64?,  Cast> (int64_hash, int64_equal);
+
 
     Array<string> keyboard_layouts { get; private set; }
 
@@ -28,6 +31,7 @@ public class Niri : Object {
 
     public List<weak Window> windows { owned get { return _windows.get_values().copy(); } }
     public List<weak Output> outputs { owned get { return _outputs.get_values().copy(); } }
+    public List<weak Cast> casts { owned get { return _casts.get_values().copy(); } }
     public List<weak Workspace> workspaces { owned get {
         var res = _workspaces.get_values().copy();
         res.sort(sort_workspaces);
@@ -55,11 +59,19 @@ public class Niri : Object {
     public signal void window_focus_changed(uint64 window_id);
     /** Window urgency changed */
     public signal void window_urgency_changed(uint64 id, bool urgent);
+
+    // A screencast started, or an existing cast changed.
+    public signal void cast_started(Cast cast);
+    // A screencast stopped.
+    public signal void cast_stopped(uint64 stream_id);
+
+
     /** Workspace urgency changed */
     public signal void workspace_urgency_changed(uint64 id, bool urgent);
     public signal void overview_opened_or_closed(bool is_open);
     public signal void keyboard_layouts_changed(Array<string> keyboard_layouts);
     public signal void keyboard_layout_switched(uint8 idx);
+
 
     private IPC? stream_socket;
     static Niri _instance;
@@ -126,6 +138,16 @@ public class Niri : Object {
 
             if (window.is_focused)
                 update_focused_window(window.id);
+        }
+
+        var casts = Json.from_string(msg.send("\"Casts\""))
+            .get_object()
+            .get_object_member("Ok")
+            .get_array_member("Casts");
+
+        foreach (var element in casts.get_elements()) {
+            var c = new Cast.from_json(element.get_object());
+            _casts.insert(c.stream_id, c);
         }
     }
 
@@ -279,6 +301,43 @@ public class Niri : Object {
                 }
                 workspace_urgency_changed(id, urgent);
                 break;
+            case "CastsChanged":
+                var casts_arr = payload.get_array_member("casts");
+
+                _casts.remove_all();
+                foreach (var element in casts_arr.get_elements()) {
+                    var cast = new Cast.from_json(element.get_object());
+                    _casts.insert(cast.stream_id, cast);
+                }
+                notify_property("casts");
+                break;
+            case "CastStartedOrChanged":
+                var cast_object = payload.get_object_member("cast");
+                var stream_id = cast_object.get_int_member("stream_id");
+
+                var cast = _casts.get(stream_id);
+
+                if (cast != null) {
+                    cast.sync(cast_object);
+                } else {
+                    cast = new Cast.from_json(cast_object);
+                    _casts.insert(stream_id, cast);
+                    cast_started(cast);
+                    notify_property("casts");
+                }
+
+                break;
+            case "CastStopped":
+                var stream_id = payload.get_int_member("stream_id");
+                var cast = _casts.take(stream_id);
+
+                cast.is_active = false;
+                cast.stopped();
+                cast_stopped(stream_id);
+                notify_property("casts");
+
+                break;
+
             case "KeyboardLayoutsChanged":
                 var layouts = payload.get_object_member("keyboard_layouts");
                 var names = layouts.get_array_member("names");
@@ -349,6 +408,19 @@ public class Niri : Object {
         if (id == 0) return null;
         return _workspaces.get(id);
     }
+
+    public unowned Output? get_output(string name) {
+        if (name == "")
+            return null;
+        return _outputs.get(name);
+    }
+
+    public unowned Cast? get_cast(uint64 id) {
+        if (id == 0)
+            return null;
+        return _casts.get(id);
+    }
+
 
     // on_workspaces_changed
     // on_workspace_activated

--- a/lib/niri/niri.vala
+++ b/lib/niri/niri.vala
@@ -410,8 +410,7 @@ public class Niri : Object {
     }
 
     public unowned Output? get_output(string name) {
-        if (name == "")
-            return null;
+        if (name == "") return null;
         return _outputs.get(name);
     }
 

--- a/lib/niri/niri.vala
+++ b/lib/niri/niri.vala
@@ -417,7 +417,7 @@ public class Niri : Object {
 
     public unowned Cast? get_cast(uint64 id) {
         if (id == 0)
-            return null;
+        if (name == "") return null;
         return _casts.get(id);
     }
 

--- a/lib/niri/niri.vala
+++ b/lib/niri/niri.vala
@@ -62,6 +62,7 @@ public class Niri : Object {
 
     // A screencast started, or an existing cast changed.
     public signal void cast_started(Cast cast);
+    public signal void casts_changed(List<weak Cast> casts);
     // A screencast stopped.
     public signal void cast_stopped(uint64 stream_id);
 
@@ -309,6 +310,7 @@ public class Niri : Object {
                     var cast = new Cast.from_json(element.get_object());
                     _casts.insert(cast.stream_id, cast);
                 }
+                casts_changed(casts);
                 notify_property("casts");
                 break;
             case "CastStartedOrChanged":
@@ -415,8 +417,7 @@ public class Niri : Object {
     }
 
     public unowned Cast? get_cast(uint64 id) {
-        if (id == 0)
-        if (name == "") return null;
+        if (id == 0) return null;
         return _casts.get(id);
     }
 

--- a/lib/niri/output.vala
+++ b/lib/niri/output.vala
@@ -52,7 +52,6 @@ public class Output : Object {
 
         foreach (var mode in object.get_array_member("modes").get_elements()) 
             modes.append_val(Mode.from_json(mode.get_object()));
-        
 
         var _current_mode = object.get_member("current_mode");
         if (_current_mode.is_null())  current_mode = -1;
@@ -65,10 +64,13 @@ public class Output : Object {
         if (_logical.is_null())  logical = null;
         else logical = LogicalOutput.from_json(_logical.get_object());
     }
+
+    public bool set_dynamic_cast() {
+        return msg.set_dynamic_cast_monitor(name);
+    }
+
     public bool focus() {
        return msg.focus_monitor(name);
     }
-
 }
-
 }

--- a/lib/niri/structs.vala
+++ b/lib/niri/structs.vala
@@ -72,6 +72,11 @@ public enum LayoutSwitchTargetTag {
   Index,
 }
 
+public enum CastKind {
+    PipeWire,
+    WlrScreencopy,
+}
+
 public struct WindowLayout {
     /**
       * Optional

--- a/lib/niri/structs.vala
+++ b/lib/niri/structs.vala
@@ -77,6 +77,14 @@ public enum CastKind {
     WlrScreencopy,
 }
 
+public enum CastTarget {
+    // "None" is used instead of "Nothing" to match the
+    // conventions used by GObject-based libraries.
+    None,
+    Output,
+    Window,
+}
+
 public struct WindowLayout {
     /**
       * Optional

--- a/lib/niri/window.vala
+++ b/lib/niri/window.vala
@@ -66,6 +66,10 @@ public class Window : Object {
         return msg.close_window((int)id);
     }
 
+    public bool set_dynamic_cast() {
+        return msg.set_dynamic_cast_window((int)id);
+    }
+
     public bool set_urgency(bool new_urgency) {
         if (is_urgent == new_urgency) return true;
         return msg.toggle_window_urgent((int) id);

--- a/lib/niri/window.vala
+++ b/lib/niri/window.vala
@@ -62,6 +62,10 @@ public class Window : Object {
         return msg.focus_window((int)id);
     }
 
+    public bool close() {
+        return msg.close_window((int)id);
+    }
+
     public bool set_urgency(bool new_urgency) {
         if (is_urgent == new_urgency) return true;
         return msg.toggle_window_urgent((int) id);


### PR DESCRIPTION
This PR adds first-class ScreenCast support to the Niri service by exposing active screencasts as objects.

ScreenCast objects provide metadata about their target (window or output) and expose lifecycle methods such as `stop()`.

Changes included:
- Added `Cast` object abstraction.
- Added `stop_cast` message handler.
- Added `Cast.stop()` support.
- Exposed screencast targets (window/output) through the new object model.  

Other:
- Added `Window.close()` convenience method.